### PR TITLE
2 model and store user data

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsserver.experimental.enableProjectDiagnostics": true
+}

--- a/migrations/20230407093651_userGameData.ts
+++ b/migrations/20230407093651_userGameData.ts
@@ -1,0 +1,24 @@
+import { Knex } from "knex";
+
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.table('users', (table) => {
+    table.bigint('gold').defaultTo(0);
+    table.json('units').defaultTo('[]');
+    table.bigint('offensive_strength').defaultTo(0);
+    table.bigint('defensive_strength').defaultTo(0);
+    table.integer('gold_per_turn').defaultTo(0);
+  });
+}
+
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.table('users', (table) => {
+    table.dropColumn('gold');
+    table.dropColumn('units');
+    table.dropColumn('offensive_strength');
+    table.dropColumn('defensive_strength');
+    table.dropColumn('gold_per_turn');
+  });
+}
+

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,14 +4,16 @@ import router from './router';
 import corsMiddleware from './middleware/cors';
 import { ulid } from 'ulid';
 import DaoFactory from './daoFactory';
+import ModelFactory from './modelFactory';
 
 export interface Context {
   requestId: string;
   config: Config;
   daoFactory: DaoFactory;
+  modelFactory: ModelFactory;
 }
 
-export default (config: Config, daoFactory: DaoFactory): Express => {
+export default (config: Config, daoFactory: DaoFactory, modelFactory: ModelFactory): Express => {
   const app = express();
 
   app.use((req, res, next) => {
@@ -20,7 +22,8 @@ export default (config: Config, daoFactory: DaoFactory): Express => {
     req.ctx = {
       requestId: requestId,
       config: config,
-      daoFactory: daoFactory
+      daoFactory: daoFactory,
+      modelFactory: modelFactory
     }
 
     res.setHeader('X-Request-Id', requestId);

--- a/src/controllers/user.ts
+++ b/src/controllers/user.ts
@@ -1,0 +1,17 @@
+import { Request, Response } from 'express';
+
+export type APIUserRecord = {
+  id: string;
+};
+
+export async function fetchUserByExternalId(req: Request, res: Response) {
+  const externalId = req.params.externalId;
+  const user = await req.ctx.modelFactory.user.fetchUserByExternalId(req.ctx, externalId);
+  if (!user) return res.status(404).json({});
+
+  const userRecord: APIUserRecord = {
+    id: user.externalId,
+  };
+
+  return res.status(200).json(userRecord);
+}

--- a/src/daoFactory.ts
+++ b/src/daoFactory.ts
@@ -1,10 +1,15 @@
 import { Knex } from 'knex';
+import UserDao from './daos/user';
 
 export default class DaoFactory {
   private database: Knex;
 
+  public user: UserDao;
+
   constructor(database: Knex) {
     this.database = database;
+
+    this.user = new UserDao(this.database);
   }
 
   async testConnection() {

--- a/src/daos/user.ts
+++ b/src/daos/user.ts
@@ -1,0 +1,33 @@
+import { Knex } from 'knex';
+
+export type UserRow = {
+  id: number;
+  external_id: string;
+  username: string;
+  password_hash: string;
+  email: string;
+  created_at: Date;
+  updated_at: Date;
+  gold: number;
+  units: string;
+  offensive_strength: number;
+  defensive_strength: number;
+  gold_per_turn: number;
+};
+
+export default class UserDao {
+  private database: Knex;
+
+  constructor(database: Knex) {
+    this.database = database;
+  }
+
+  async fetchUserByExternalId(externalId: string): Promise<UserRow | null> {
+    const user = await this.database<UserRow>('users')
+      .select()
+      .where({ external_id: externalId })
+      .first();
+
+    return user || null;
+  }
+}

--- a/src/modelFactory.ts
+++ b/src/modelFactory.ts
@@ -1,0 +1,9 @@
+import UserModel from './models/user';
+
+export default class ModelFactory {
+  public user: typeof UserModel;
+
+  constructor() {
+    this.user = UserModel;
+  }
+}

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,0 +1,43 @@
+import { Context } from '../app';
+import { UserRow } from '../daos/user';
+
+export default class UserModel {
+  private ctx: Context;
+
+  public id: number;
+  public externalId: string;
+  public username: string;
+  public passwordHash: string;
+  public email: string;
+  public createdAt: Date;
+  public updatedAt: Date;
+  public gold: number;
+  public units: string;
+  public offensiveStrength: number;
+  public defensiveStrength: number;
+  public goldPerTurn: number;
+ 
+  constructor(ctx: Context, userData: UserRow) {
+    this.ctx = ctx;
+
+    this.id = userData.id;
+    this.externalId = userData.external_id;
+    this.username = userData.username;
+    this.passwordHash = userData.password_hash;
+    this.email = userData.email;
+    this.createdAt = userData.created_at;
+    this.updatedAt = userData.updated_at;
+    this.gold = userData.gold;
+    this.units = userData.units;
+    this.offensiveStrength = userData.offensive_strength;
+    this.defensiveStrength = userData.defensive_strength;
+    this.goldPerTurn = userData.gold_per_turn;
+  }
+
+  static async fetchUserByExternalId(ctx: Context, externalId: string): Promise<UserModel | null> {
+    const user = await ctx.daoFactory.user.fetchUserByExternalId(externalId);
+    if (!user) return null;
+
+    return new UserModel(ctx, user);
+  }
+}

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,8 +1,11 @@
 import { Router, Request, Response } from 'express';
 import { healthcheck } from './controllers/healthcheck';
+import { fetchUserByExternalId } from './controllers/user';
 
 const router = Router();
 
 router.get('/healthcheck', healthcheck);
+
+router.get('/user/:externalId', fetchUserByExternalId);
 
 export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,11 +3,13 @@ import App from './app';
 import Knex from 'knex';
 import knexConfig from '../knexfile';
 import DaoFactory from './daoFactory';
+import ModelFactory from './modelFactory';
 
 const knex = Knex(knexConfig[config.environment]);
 const daoFactory = new DaoFactory(knex);
+const modelFactory = new ModelFactory();
 
-const app = App(config, daoFactory);
+const app = App(config, daoFactory, modelFactory);
 
 app.listen(config.serverPort, () => {
   console.log('Server started');

--- a/tests/unit/controllers/healthcheck.spec.ts
+++ b/tests/unit/controllers/healthcheck.spec.ts
@@ -2,6 +2,7 @@ import request from 'supertest';
 import app from '../../../src/app';
 import { Config } from '../../../config/config';
 import DaoFactory from '../../../src/daoFactory';
+import ModelFactory from '../../../src/modelFactory';
 
 describe('Healthcheck controller', () => {
   describe('GET /healthcheck', () => {
@@ -13,7 +14,7 @@ describe('Healthcheck controller', () => {
       const mockDaoFactory = {
         testConnection: jest.fn().mockResolvedValue(true)
       } as unknown as DaoFactory;
-      const mockApp = app(mockConfig, mockDaoFactory);
+      const mockApp = app(mockConfig, mockDaoFactory, {} as unknown as ModelFactory);
 
       const response = await request(mockApp).get('/healthcheck');
 
@@ -27,7 +28,7 @@ describe('Healthcheck controller', () => {
       const mockDaoFactory = {
         testConnection: jest.fn().mockResolvedValue(true)
       } as unknown as DaoFactory;
-      const mockApp = app(mockConfig, mockDaoFactory);
+      const mockApp = app(mockConfig, mockDaoFactory, {} as unknown as ModelFactory);
 
       const response = await request(mockApp).get('/healthcheck');
 
@@ -42,7 +43,7 @@ describe('Healthcheck controller', () => {
       const mockDaoFactory = {
         testConnection: jest.fn().mockResolvedValue(true)
       } as unknown as DaoFactory;
-      const mockApp = app(mockConfig, mockDaoFactory);
+      const mockApp = app(mockConfig, mockDaoFactory, {} as unknown as ModelFactory);
 
       const response = await request(mockApp).get('/healthcheck');
       
@@ -63,7 +64,7 @@ describe('Healthcheck controller', () => {
       const mockDaoFactory = {
         testConnection: jest.fn().mockResolvedValue(false)
       } as unknown as DaoFactory;
-      const mockApp = app(mockConfig, mockDaoFactory);
+      const mockApp = app(mockConfig, mockDaoFactory, {} as unknown as ModelFactory);
 
       const response = await request(mockApp).get('/healthcheck');
       

--- a/tests/unit/controllers/user.spec.ts
+++ b/tests/unit/controllers/user.spec.ts
@@ -1,0 +1,51 @@
+import { Request, Response } from 'express';
+import { fetchUserByExternalId } from '../../../src/controllers/user';
+import UserModel from '../../../src/models/user';
+
+describe('Controller: User', () => {
+  describe('GET /user/:userId', () => {
+    it('should return a 404 if the user does not exist', async () => {
+      const mockRequest = _mockRequest(null);
+      const mockResponse = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn().mockReturnThis(),
+      } as unknown as Response;
+      await fetchUserByExternalId(mockRequest, mockResponse);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(404);
+      expect(mockResponse.json).toHaveBeenCalledWith({});
+    });
+    it('should return a 200 if the user exists', async () => {
+      const mockRequest = _mockRequest(
+        {
+          externalId: 'abc123',
+        } as UserModel
+      );
+      const mockResponse = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn().mockReturnThis(),
+      } as unknown as Response;
+      await fetchUserByExternalId(mockRequest, mockResponse);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(200);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        id: 'abc123',
+      });
+    });
+  });
+});
+
+const _mockRequest = (user: UserModel | null): Request => {
+  return {
+    params: {
+      externalId: 'abc123',
+    },
+    ctx: {
+      modelFactory: {
+        user: {
+          fetchUserByExternalId: jest.fn().mockResolvedValue(user),
+        },
+      },
+    },
+  } as unknown as Request;
+}

--- a/tests/unit/daos/user.spec.ts
+++ b/tests/unit/daos/user.spec.ts
@@ -1,0 +1,39 @@
+import { Knex } from 'knex';
+import UserDao from '../../../src/daos/user';
+
+describe('Dao: User', () => {
+  describe('fetchUserByExternalId', () => {
+    it('should return null if no user is found', async () => {
+      const mockKnex = _mockDatabase(null);
+      const userDao = new UserDao(mockKnex);
+      const user = await userDao.fetchUserByExternalId('123');
+      expect(user).toBeNull();
+    });
+    it('should return a user if one is found', async () => {
+      const mockKnex = _mockDatabase({
+        id: 1,
+        external_id: '123',
+      });
+      const userDao = new UserDao(mockKnex);
+      const user = await userDao.fetchUserByExternalId('123');
+      expect(user).not.toBeNull();
+    });
+    it('should return a user with the correct external id', async () => {
+      const mockKnex = _mockDatabase({
+        id: 1,
+        external_id: '123',
+      });
+      const userDao = new UserDao(mockKnex);
+      const user = await userDao.fetchUserByExternalId('123');
+      expect(user?.external_id).toEqual('123');
+    });
+  });
+});
+
+function _mockDatabase(returnValue: any): Knex {
+  return jest.fn().mockReturnValue({
+    select: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    first: jest.fn().mockResolvedValue(returnValue),
+  }) as unknown as Knex;
+}

--- a/tests/unit/models/user.spec.ts
+++ b/tests/unit/models/user.spec.ts
@@ -1,0 +1,76 @@
+import { Context } from '../../../src/app';
+import { UserRow } from '../../../src/daos/user';
+import UserModel from '../../../src/models/user';
+
+// Mock user data
+const mockUserData: UserRow = {
+  id: 1,
+  external_id: 'abc123',
+  username: 'testuser',
+  password_hash: 'passwordhash',
+  email: 'testuser@example.com',
+  created_at: new Date(),
+  updated_at: new Date(),
+  gold: 100,
+  units: '[]',
+  offensive_strength: 50,
+  defensive_strength: 50,
+  gold_per_turn: 10,
+};
+
+describe('Model: User', () => {
+  describe('constructor', () => {
+    it('should create a new user model', () => {
+      const ctx = _mockContext(mockUserData);
+      const user = new UserModel(ctx, mockUserData);
+      expect(user).not.toBeNull();
+    });
+    it('should populate the user model with the correct data', () => {
+      const ctx = _mockContext(mockUserData);
+      const user = new UserModel(ctx, mockUserData);
+
+      // This will fail if you add a new property to the UserModel class without updating this test
+      expect(Object.keys(user).length).toEqual(13);
+
+      expect(user.id).toEqual(mockUserData.id);
+      expect(user.externalId).toEqual(mockUserData.external_id);
+      expect(user.username).toEqual(mockUserData.username);
+      expect(user.passwordHash).toEqual(mockUserData.password_hash);
+      expect(user.email).toEqual(mockUserData.email);
+      expect(user.createdAt).toEqual(mockUserData.created_at);
+      expect(user.updatedAt).toEqual(mockUserData.updated_at);
+      expect(user.gold).toEqual(mockUserData.gold);
+      expect(user.units).toEqual(mockUserData.units);
+      expect(user.offensiveStrength).toEqual(mockUserData.offensive_strength);
+      expect(user.defensiveStrength).toEqual(mockUserData.defensive_strength);
+      expect(user.goldPerTurn).toEqual(mockUserData.gold_per_turn);
+    });
+  });
+  describe('fetchUserByExternalId', () => {
+    it('should return null if no user is found', async () => {
+      const ctx = _mockContext(null);
+      const user = await UserModel.fetchUserByExternalId(ctx, 'abc123');
+      expect(user).toBeNull();
+    });
+    it('should return a user if one is found', async () => {
+      const ctx = _mockContext(mockUserData);
+      const user = await UserModel.fetchUserByExternalId(ctx, 'abc123');
+      expect(user).not.toBeNull();
+    });
+    it('should return a user with the correct external id', async () => {
+      const ctx = _mockContext(mockUserData);
+      const user = await UserModel.fetchUserByExternalId(ctx, 'abc123');
+      expect(user?.externalId).toEqual('abc123');
+    });
+  });
+});
+
+const _mockContext = (user: UserRow | null): Context => {
+  return {
+    daoFactory: {
+      user: {
+        fetchUserByExternalId: jest.fn().mockResolvedValue(user),
+      },
+    },
+  } as unknown as Context;
+};


### PR DESCRIPTION
Fixes #2 

This PR introduces user data required for functional play. It also introduces code scaffolding for building user-based functionality.

I split the integration between the database and the application logic with a DAO (Data Access Object) layer. This abstracts the business logic from data persistence making it a simple job to replace the storage tech if desired in the future.